### PR TITLE
Add forwarded for IP to request logs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,8 @@ internals.update = function (event, request) {
         update.request = {
             id: request.id,
             received: request.info.received,
-            elapsed: now - request.info.received
+            elapsed: now - request.info.received,
+            remoteIP: request.headers['x-forwarded-for']
         };
     }
 


### PR DESCRIPTION
Since this is stringified, and will be undefined if not passed, this has no impact on the log output for systems that don't involve this header.