### PR TITLE
Make the tests tighter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,7 @@ internals.update = function (event, request) {
     const now = Date.now();
 
     const update = {
-        event: event,
+        event,
         timestamp: now,
         host: Os.hostname()
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bananas",
   "description": "Minimal Loggly hapi plugin",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Eran Hammer <eran@hammer.io> (http://hueniverse.com)",
   "repository": "git://github.com/hueniverse/bananas",
   "main": "lib/index.js",
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "hoek": "4.x.x",
-    "wreck": "8.x.x",
+    "wreck": "9.x.x",
     "fast-safe-stringify": "1.x.x"
   },
   "devDependencies": {
     "code": "3.x.x",
-    "hapi": "14.x.x",
-    "lab": "10.x.x"
+    "hapi": "15.x.x",
+    "lab": "11.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L -m 5000",

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,13 @@ const expect = Code.expect;
 
 describe('Bananas', () => {
 
+    const originalPost = Wreck.post;
+    lab.afterEach((done) => {
+
+        Wreck.post = originalPost;
+        done();
+    });
+
     it('logs error events', { parallel: false }, (done) => {
 
         const server = new Hapi.Server({ debug: false });
@@ -37,9 +44,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -136,7 +145,6 @@ describe('Bananas', () => {
                             }
                         ]);
 
-                        Wreck.post = orig;
                         server.stop((err) => {
 
                             expect(err).to.not.exist();
@@ -154,14 +162,16 @@ describe('Bananas', () => {
         server.connection();
 
         const settings = {
-            token: 'abcdefg',
+            token: 'gfedcba',
             intervalMsec: 50
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/gfedcba');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -188,7 +198,6 @@ describe('Bananas', () => {
                     setTimeout(() => {
 
                         expect(updates.length).to.equal(2);
-                        Wreck.post = orig;
 
                         server.stop((err) => {
 
@@ -211,9 +220,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -241,7 +252,6 @@ describe('Bananas', () => {
                     setTimeout(() => {
 
                         expect(updates.length).to.equal(2);
-                        Wreck.post = orig;
 
                         server.stop((err) => {
 
@@ -266,9 +276,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -306,7 +318,6 @@ describe('Bananas', () => {
                         setTimeout(() => {
 
                             expect(updates.length).to.equal(2);
-                            Wreck.post = orig;
 
                             server.stop((err) => {
 
@@ -332,9 +343,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -368,7 +381,6 @@ describe('Bananas', () => {
                     setTimeout(() => {
 
                         expect(updates.length).to.equal(1);
-                        Wreck.post = orig;
 
                         server.stop((err) => {
 
@@ -393,9 +405,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -404,7 +418,6 @@ describe('Bananas', () => {
         process.exit = (code) => {
 
             process.exit = exit;
-            Wreck.post = orig;
 
             expect(updates.length).to.equal(2);
             expect(code).to.equal(1);
@@ -430,9 +443,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -441,7 +456,6 @@ describe('Bananas', () => {
         process.exit = (code) => {
 
             process.exit = exit;
-            Wreck.post = orig;
 
             updates = updates.map(JSON.parse);
             expect(updates).to.equal([
@@ -486,9 +500,11 @@ describe('Bananas', () => {
         };
 
         let updates = [];
-        const orig = Wreck.post;
         Wreck.post = function (uri, options, next) {
 
+            expect(uri).to.equal('https://logs-01.loggly.com/bulk/abcdefg');
+            expect(options.json).to.be.true();
+            expect(options.headers).to.equal({ 'content-type': 'application/json' });
             updates = updates.concat(options.payload.split('\n'));
             return next();
         };
@@ -497,7 +513,6 @@ describe('Bananas', () => {
         process.exit = (code) => {
 
             process.exit = exit;
-            Wreck.post = orig;
 
             updates = updates.map(JSON.parse);
             expect(updates).to.equal([

--- a/test/index.js
+++ b/test/index.js
@@ -148,6 +148,14 @@ describe('Bananas', () => {
                         server.stop((err) => {
 
                             expect(err).to.not.exist();
+                            expect(updates.length).to.equal(6);
+                            const lastUpdate = JSON.parse(updates[5]);
+                            expect(lastUpdate).to.equal({
+                                event: 'server',
+                                timestamp: lastUpdate.timestamp,
+                                host: Os.hostname(),
+                                tags: ['test', 'bananas', 'stopped']
+                            });
                             done();
                         });
                     }, 200);

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,7 @@ describe('Bananas', () => {
             return next();
         };
 
+        const timeBeforeBananasRegister = new Date();
         server.register({ register: Bananas, options: settings }, (err) => {
 
             expect(err).to.not.exist();
@@ -67,9 +68,11 @@ describe('Bananas', () => {
                 }
             });
 
+            const timeBeforeServerStart = new Date();
             server.start((err) => {
 
                 expect(err).to.not.exist();
+                const timeBeforeInject = new Date();
 
                 server.inject('/', (res) => {
 
@@ -145,6 +148,15 @@ describe('Bananas', () => {
                             }
                         ]);
 
+                        expect(new Date(updates[0].timestamp)).to.be.between(timeBeforeBananasRegister, new Date());
+                        expect(new Date(updates[1].timestamp)).to.be.between(timeBeforeServerStart, new Date());
+
+                        updates.slice(2).forEach((update) => {
+
+                            expect(new Date(update.timestamp)).to.be.between(timeBeforeInject, new Date());
+                        });
+
+                        const timeBeforeStop = new Date();
                         server.stop((err) => {
 
                             expect(err).to.not.exist();
@@ -156,6 +168,7 @@ describe('Bananas', () => {
                                 host: Os.hostname(),
                                 tags: ['test', 'bananas', 'stopped']
                             });
+                            expect(new Date(lastUpdate.timestamp)).to.be.between(timeBeforeStop, new Date());
                             done();
                         });
                     }, 200);

--- a/test/index.js
+++ b/test/index.js
@@ -500,6 +500,8 @@ describe('Bananas', () => {
                     tags: ['test', 'bananas', 'stopped']
                 }
             ]);
+            expect(process.listenerCount('SIGTERM')).to.equal(0);
+            expect(process.listenerCount('SIGINT')).to.equal(0);
             done();
         };
 
@@ -557,6 +559,8 @@ describe('Bananas', () => {
                     tags: ['bananas', 'stopped']
                 }
             ]);
+            expect(process.listenerCount('SIGTERM')).to.equal(0);
+            expect(process.listenerCount('SIGINT')).to.equal(0);
             done();
         };
 

--- a/test/index.js
+++ b/test/index.js
@@ -86,25 +86,18 @@ describe('Bananas', () => {
                                 tags: ['test', 'server event']
                             },
                             {
-                                event: 'error',
+                                event: 'server',
                                 timestamp: updates[2].timestamp,
                                 host: Os.hostname(),
-                                tags: ['test'],
-                                path: '/',
-                                query: {},
-                                method: 'get',
-                                request: {
-                                    id: updates[2].request.id,
-                                    received: updates[2].request.received,
-                                    elapsed: updates[2].request.elapsed
-                                },
-                                error: {
-                                    message: 'Uncaught error: boom',
-                                    stack: updates[2].error.stack
+                                tags: ['test', 'some', 'tags'],
+                                data: {
+                                    message: 'oops',
+                                    stack: updates[2].data.stack,
+                                    data: 42
                                 }
                             },
                             {
-                                event: 'response',
+                                event: 'error',
                                 timestamp: updates[3].timestamp,
                                 host: Os.hostname(),
                                 tags: ['test'],
@@ -116,22 +109,29 @@ describe('Bananas', () => {
                                     received: updates[3].request.received,
                                     elapsed: updates[3].request.elapsed
                                 },
+                                error: {
+                                    message: 'Uncaught error: boom',
+                                    stack: updates[3].error.stack
+                                }
+                            },
+                            {
+                                event: 'response',
+                                timestamp: updates[4].timestamp,
+                                host: Os.hostname(),
+                                tags: ['test'],
+                                path: '/',
+                                query: {},
+                                method: 'get',
+                                request: {
+                                    id: updates[4].request.id,
+                                    received: updates[4].request.received,
+                                    elapsed: updates[4].request.elapsed
+                                },
                                 code: 500,
                                 error: {
                                     statusCode: 500,
                                     error: 'Internal Server Error',
                                     message: 'An internal server error occurred'
-                                }
-                            },
-                            {
-                                event: 'server',
-                                timestamp: updates[4].timestamp,
-                                host: Os.hostname(),
-                                tags: ['test', 'some', 'tags'],
-                                data: {
-                                    message: 'oops',
-                                    stack: updates[4].data.stack,
-                                    data: 42
                                 }
                             }
                         ]);


### PR DESCRIPTION
Hi,

I was going over the tests to see how to use the module and I found some untested areas. 
There were also actual calls to loggly API during the tests, because when the server stops a log event is emitted - I guessed it wasn't intentional, so I moved some stuff to the `afterEach` function.
