### PR TITLE
Include route path in its parametric/template form

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,6 +198,8 @@ internals.update = function (event, request) {
     if (request) {
         update.path = request.path;
         update.query = request.query;
+        update.params = request.params;
+        update.routePath = request.route.path;
         update.method = request.method;
         update.request = {
             id: request.id,

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,6 +185,8 @@ internals.update = function (event, request) {
     if (request) {
         update.path = request.path;
         update.query = request.query;
+        update.params = request.params;
+        update.routePath = request.route.path;
         update.method = request.method;
         update.request = {
             id: request.id,

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,7 @@ describe('Bananas', () => {
             expect(err).to.not.exist();
 
             server.route({
-                path: '/',
+                path: '/{param1}/b/{param2}',
                 method: 'GET',
                 handler: function (request, reply) {
 
@@ -77,7 +77,7 @@ describe('Bananas', () => {
                 expect(err).to.not.exist();
                 const timeBeforeInject = new Date();
 
-                server.inject('/', (res) => {
+                server.inject('/123/b/456', (res) => {
 
                     const error = new Error('oops');
                     error.data = 42;
@@ -116,7 +116,12 @@ describe('Bananas', () => {
                                 timestamp: updates[3].timestamp,
                                 host: Os.hostname(),
                                 tags: ['test', 'test2'],
-                                path: '/',
+                                path: '/123/b/456',
+                                routePath: '/{param1}/b/{param2}',
+                                params: {
+                                    param1: '123',
+                                    param2: '456'
+                                },
                                 query: {},
                                 method: 'get',
                                 request: {
@@ -134,7 +139,12 @@ describe('Bananas', () => {
                                 timestamp: updates[4].timestamp,
                                 host: Os.hostname(),
                                 tags: ['test', 'test2'],
-                                path: '/',
+                                path: '/123/b/456',
+                                routePath: '/{param1}/b/{param2}',
+                                params: {
+                                    param1: '123',
+                                    param2: '456'
+                                },
                                 query: {},
                                 method: 'get',
                                 request: {

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ describe('Bananas', () => {
             expect(err).to.not.exist();
 
             server.route({
-                path: '/',
+                path: '/{param1}/b/{param2}',
                 method: 'GET',
                 handler: function (request, reply) {
 
@@ -79,7 +79,7 @@ describe('Bananas', () => {
                 expect(err).to.not.exist();
                 const timeBeforeInject = new Date();
 
-                server.inject('/', (res) => {
+                server.inject('/123/b/456', (res) => {
 
                     const error = new Error('oops');
                     error.data = 42;
@@ -118,7 +118,12 @@ describe('Bananas', () => {
                                 timestamp: updates[3].timestamp,
                                 host: Os.hostname(),
                                 tags: ['test', 'test2'],
-                                path: '/',
+                                path: '/123/b/456',
+                                routePath: '/{param1}/b/{param2}',
+                                params: {
+                                    param1: '123',
+                                    param2: '456'
+                                },
                                 query: {},
                                 method: 'get',
                                 request: {
@@ -136,7 +141,12 @@ describe('Bananas', () => {
                                 timestamp: updates[4].timestamp,
                                 host: Os.hostname(),
                                 tags: ['test', 'test2'],
-                                path: '/',
+                                path: '/123/b/456',
+                                routePath: '/{param1}/b/{param2}',
+                                params: {
+                                    param1: '123',
+                                    param2: '456'
+                                },
                                 query: {},
                                 method: 'get',
                                 request: {


### PR DESCRIPTION
Hi,

I find it helpful to have the route path together with the path
For example, you could filter by `json.routePath: "/users/{id}"` and you can see the breakdown of the average elapsed time for each routePath
